### PR TITLE
Add interactive chat-build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ golf run
 ```
 This will start the FastMCP server, typically on `http://127.0.0.1:3000` (configurable in `golf.json`). The `dev` command includes hot reloading, so changes to your component files will automatically restart the server.
 
+### 4. Interactive Build
+
+If you'd like to configure build settings interactively, run:
+
+```bash
+golf chat-build
+```
+This command will prompt you for options such as project name, host, and port before building.
+
 That's it! Your Golf server is running and ready for integration.
 
 ## Basic Project Structure

--- a/src/golf/cli/main.py
+++ b/src/golf/cli/main.py
@@ -145,6 +145,19 @@ def build_prod(
     build_project(project_root, settings, output_dir, build_env="prod", copy_env=False)
 
 
+@app.command("chat-build")
+def chat_build_cmd(
+    output_dir: Optional[str] = typer.Option(
+        None, "--output-dir", "-o", help="Directory to output the built project"
+    )
+) -> None:
+    """Interactively configure and build the project."""
+
+    from golf.commands.chat_build import chat_build
+
+    chat_build(output_dir)
+
+
 @app.command()
 def run(
     dist_dir: Optional[str] = typer.Option(

--- a/src/golf/commands/__init__.py
+++ b/src/golf/commands/__init__.py
@@ -1,3 +1,4 @@
 """GolfMCP command implementations."""
 
-from golf.commands import init, build, run 
+from golf.commands import build, init, run
+from golf.commands import chat_build  # noqa: F401

--- a/src/golf/commands/chat_build.py
+++ b/src/golf/commands/chat_build.py
@@ -1,0 +1,57 @@
+"""Interactive build command for GolfMCP."""
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+from golf.core.config import load_settings, find_project_root
+from golf.commands.build import build_project
+
+console = Console()
+
+
+def chat_build(output_dir: Optional[str] = None) -> None:
+    """Interactively gather settings and build the project.
+
+    Args:
+        output_dir: Directory to output the built project (defaults to ./dist)
+    """
+    project_root, _ = find_project_root()
+    if not project_root:
+        console.print(
+            "[bold red]Error: No GolfMCP project found in the current directory or any parent directory.[/bold red]"
+        )
+        console.print("Run 'golf init <project_name>' to create a new project.")
+        raise typer.Exit(code=1)
+
+    settings = load_settings(project_root)
+
+    console.print("[bold green]Interactive build configuration[/bold green]")
+
+    name = typer.prompt("Project name", default=settings.name)
+    description = typer.prompt("Description", default=settings.description or "")
+    host = typer.prompt("Server host", default=settings.host)
+    port = typer.prompt("Server port", default=str(settings.port))
+    build_env = typer.prompt("Build environment (dev/prod)", default="prod")
+    copy_env = typer.confirm(
+        "Copy environment variables into build?", default=(build_env == "dev")
+    )
+
+    if output_dir is None:
+        output_path = project_root / "dist"
+    else:
+        output_path = Path(output_dir)
+
+    # Update settings with answers
+    settings.name = name
+    settings.description = description
+    settings.host = host
+    try:
+        settings.port = int(port)
+    except ValueError:
+        console.print("[yellow]Invalid port; using existing value.[/yellow]")
+
+    build_project(project_root, settings, output_path, build_env=build_env, copy_env=copy_env)
+    console.print("[bold green]Build complete.[/bold green]")


### PR DESCRIPTION
## Summary
- add an interactive build command that prompts for settings
- expose the command in the CLI as `chat-build`
- document usage in README

## Testing
- `ruff check .` *(fails: unrecognized subcommand or style issues)*
- `mypy src/golf/commands/chat_build.py` *(fails: missing imports)*